### PR TITLE
better parallelism, faster regression

### DIFF
--- a/theforce/calculator/README.md
+++ b/theforce/calculator/README.md
@@ -212,6 +212,7 @@ For setting the hyper-parameter optimization (HPO) frequency.
 * 0 -> once for every LCE/data sampled
 * 1 -> only if n.o. LCE + n.o. data sampled > 0 (in 1 MD step)
 * 2 -> only if new data are sampled
+* i>2 -> only when n.o. sampled data is divisible by (i-1)
 
 Frequency of HPOs decrease dramatically with increasing ioptim:
 0 >> 1 >> 2. Default is ioptim = 1.

--- a/theforce/calculator/active.py
+++ b/theforce/calculator/active.py
@@ -761,7 +761,7 @@ class ActiveCalculator(Calculator):
         self._calc = _calc
         self.tune_for_md = tune_for_md
 
-    def include_tape(self, tape):
+    def include_tape(self, tape, ndata=None):
         if type(tape) == str:
             tape = SgprIO(tape)
         _calc = self._calc
@@ -782,6 +782,7 @@ class ActiveCalculator(Calculator):
 
         #
         added_lce = [0, 0]
+        cdata = 0
         for cls, obj in tape.read():
             if cls == 'atoms':
                 if abs(obj.get_forces()).max() > self.include_params['fmax']:
@@ -793,6 +794,9 @@ class ActiveCalculator(Calculator):
                 obj.set_calculator(self)
                 obj.get_potential_energy()
                 obj.set_calculator(self._calc)
+                cdata += 1
+                if ndata and cdata >= ndata:
+                    break
                 added_lce = [0, 0]
             elif cls == 'local':
                 obj.stage(self.model.descriptors, True)

--- a/theforce/calculator/active.py
+++ b/theforce/calculator/active.py
@@ -232,7 +232,7 @@ class ActiveCalculator(Calculator):
         Calculator.__init__(self)
         self._calc = calculator
         self.process_group = process_group
-        self.distrib = Distributer(torch.distributed.get_world_size())
+        self.distrib = Distributer(self.world_size)
         self.pckl = pckl
         self.get_model(covariance, kernel_kw or {})
         self.ediff = ediff
@@ -832,6 +832,13 @@ class ActiveCalculator(Calculator):
             return torch.distributed.get_rank()
         else:
             return 0
+
+    @property
+    def world_size(self):
+        if torch.distributed.is_initialized():
+            return torch.distributed.get_world_size()
+        else:
+            return 1
 
     def log(self, mssge, mode='a'):
         if self.logfile and self.rank == 0:

--- a/theforce/calculator/active.py
+++ b/theforce/calculator/active.py
@@ -252,8 +252,8 @@ class ActiveCalculator(Calculator):
         self.log(f'kernel: {self.model.descriptors}')
         self.log_settings()
         self.log('model size: {} {}'.format(*self.size))
-        self.tape = SgprIO(tape)
-        # if self.active:
+        self.tape = None if tape is None else SgprIO(tape)
+        # if self.active and self.tape:
         #    self.tape.write_params(ediff=self.ediff, ediff_tot=self.ediff_tot,
         #                           fdiff=self.fdiff)
         self.test = test
@@ -446,8 +446,9 @@ class ActiveCalculator(Calculator):
         inducing = LocalsData([self.atoms.local(j, detach=True) for j in i])
         self.model.set_data(data, inducing)
         # data is stored in _exact, thus we only store the inducing
-        for loc in inducing:
-            self.tape.write(loc)
+        if self.tape:
+            for loc in inducing:
+                self.tape.write(loc)
         details = [(j, self.atoms.numbers[j]) for j in i]
         self.log('seed size: {} {} details: {}'.format(
             *self.size, details))
@@ -519,7 +520,8 @@ class ActiveCalculator(Calculator):
         tmp.set_calculator(self._calc)
         energy = tmp.get_potential_energy()
         forces = tmp.get_forces()
-        self.tape.write(tmp)
+        if self.tape:
+            self.tape.write(tmp)
         self.log('exact energy: {}'.format(energy))
         #
         if self.model.ndata > 0:
@@ -628,7 +630,8 @@ class ActiveCalculator(Calculator):
                 self.model.pop_1inducing(clear_cached=True)
                 added = 0
             else:
-                self.tape.write(loc)
+                if self.tape:
+                    self.tape.write(loc)
                 if self.ioptim == 0:
                     self.optimize()
         return added

--- a/theforce/calculator/socketcalc.py
+++ b/theforce/calculator/socketcalc.py
@@ -61,9 +61,11 @@ class SocketCalculator(Calculator):
             s.send(self.message.encode())
             ierr = int(s.recv(1024).decode('utf-8'))
             s.close()
-        assert ierr == 0
         if self.is_distributed:
+            ierr = torch.tensor(ierr)
+            torch.distributed.broadcast(ierr, 0)
             torch.distributed.barrier()
+        assert ierr == 0
         self.log('e')
         # read
         atms = read('socket_recv.xyz')

--- a/theforce/cl/README.md
+++ b/theforce/cl/README.md
@@ -41,6 +41,7 @@ test:            integer; single-point testing intervals (default=None)
 ediff:     (eV)  energy sensitivity for sampling LCEs (default ~ 2 kcal/mol)
 fdiff:    (eV/A) forces sensitivity for sampling Ab initio data (default ~ 3 kcal/mol)
 noise_f:  (ev/A) bias noise for forces (default ~ 1 kcal/mol)
+ioptim:          for hyper-parameter optimization frequency (default=1)
 max_data:        max data size (default=inf)
 max_inducing:    max inducing size (default=inf)
 ```
@@ -83,6 +84,14 @@ For this, all you need to do is to not specify any
 The other paramteres (`ediff`, `fdiff`) which control 
 the sampling and accuracy should be gradually tuned to 
 get the desired accuracy.
+
+If `ioptim = 0`, hyper-parameters are (re)optimized
+for every data/LCE increament. This can dramatically
+slow down MLMD. If `ioptim = 1` the model is
+(re)optimized once for every step that
+total increaments are nonzero. If `ioptim = i`
+where i>1, the model is (re)optimized only
+when n.o. sampled data is divisible by (i-1).
 
 If the size of accumulated data/inducing becomes too large,
 the simulation may become too slow.

--- a/theforce/cl/__init__.py
+++ b/theforce/cl/__init__.py
@@ -4,6 +4,8 @@ from theforce.util.parallel import mpi_init
 from theforce.calculator.socketcalc import SocketCalculator
 from theforce.calculator.active import ActiveCalculator, kcal_mol, inf, SeSoapKernel, DefaultRadii, ActiveMeta
 from theforce.calculator.meta import Meta, Posvar, Qlvar, Catvar
+import torch
+import torch.distributed as dist
 import os
 import time
 import atexit
@@ -45,8 +47,13 @@ def gen_active_calc(**over):
 
 
 def print_stop_time():
+    dist.barrier()
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    threads = torch.get_num_threads()
     stop_time = time.time() - start_time
-    print(f'\n\tstopwatch: \t {stop_time} seconds')
+    print(
+        f'\n\tstopwatch (process: {rank}/{world}, threads: {threads}): \t {stop_time} seconds')
 
 
 # at exit

--- a/theforce/cl/__init__.py
+++ b/theforce/cl/__init__.py
@@ -52,8 +52,11 @@ def print_stop_time():
     world = dist.get_world_size()
     threads = torch.get_num_threads()
     stop_time = time.time() - start_time
-    print(
-        f'\n\tstopwatch (process: {rank}/{world}, threads: {threads}): \t {stop_time} seconds')
+    for i in range(world):
+        if rank == i:
+            print(
+                f'\tstopwatch (process: {rank}/{world}, threads: {threads}): \t {stop_time} seconds')
+        dist.barrier()
 
 
 # at exit

--- a/theforce/cl/train.py
+++ b/theforce/cl/train.py
@@ -9,9 +9,14 @@ def train(*args, r=None):
     for arg in args:
         if arg.endswith('.sgpr'):
             if r is not None and r != '::':
-                w = f'-r {r} option is ignored for {arg}'
-                warnings.warn(w)
-            calc.include_tape(arg)
+                try:
+                    ndata = int(r)
+                except:
+                    raise RuntimeError(
+                        'For .sgpr files use -r with an integer (e.g. -r 100)')
+            else:
+                ndata = None
+            calc.include_tape(arg, ndata=ndata)
         else:
             data = read(arg) if r is None else read(arg, r)
             calc.include_data(data)

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -240,6 +240,12 @@ class Distributer:
                 self.total[rank] += 1
             atoms.ranks = ranks
 
+    def upload(self, atoms):
+        if atoms.ranks is not None:
+            for z, rank in zip(atoms.numbers, atoms.ranks):
+                self.loads[z][rank] += 1
+                self.total[rank] += 1
+
     def unload(self, atoms):
         if atoms.ranks is not None:
             for z, rank in zip(atoms.numbers, atoms.ranks):

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -259,6 +259,7 @@ class TorchAtoms(Atoms):
 
         # ------------------------------- ----------
         if type(ranks) == Distributer:
+            self.ranks = None
             ranks(self)
         else:
             self.ranks = ranks

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -448,10 +448,11 @@ class TorchAtoms(Atoms):
         new = TorchAtoms(positions=self.positions.copy(),
                          cell=self.cell.copy(),
                          numbers=self.numbers.copy(),
-                         pbc=self.pbc.copy())
+                         pbc=self.pbc.copy(),
+                         ranks=self.ranks)
         if group and self.is_distributed:
             new.attach_process_group(self.process_group)
-            new.indices = self.indices  # TODO: ignore?
+            assert new.indices == self.indices  # TODO: ignore?
         if update:
             new.update(cutoff=self.cutoff, descriptors=self.descriptors)
         vel = self.get_velocities()

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -7,6 +7,7 @@ from theforce.regression.algebra import jitcholesky, projected_process_auxiliary
 from theforce.regression.scores import coeff_of_determination
 from theforce.similarity.similarity import SimilarityKernel
 from theforce.util.util import iterable, mkdir_p, safe_dirname
+from theforce.util.parallel import if_master
 from theforce.descriptor.atoms import Local, TorchAtoms, AtomsData, LocalsData
 from collections import Counter
 from scipy.optimize import minimize
@@ -987,13 +988,12 @@ class PosteriorPotential(Module):
         self.data = data
         self.gp.cahced = cached
 
+    @if_master
     def to_folder(self, folder, info=None, overwrite=True, supress_warnings=True, pickle_data=False,
                   to_traj=False):
         if pickle_data and self.data.is_distributed:
             raise NotImplementedError(
                 'trying to pickle data which is distributed! call gathere_() first!')
-        if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
-            return
         if not overwrite:
             folder = safe_dirname(folder)
         mkdir_p(folder)

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -1184,19 +1184,21 @@ def _regression(self, optimize=False, noise_f=None, max_noise=0.99, same_sigma=T
             return float(loss)
 
     if optimize:
-        # find approx global min on a grid
-        if same_sigma:
-            grid = torch.arange(.1, 5., 0.2).neg().exp()
-            losses = {}
-            for sig in grid:
-                self._noise['all'] = to_inf_inf(sig)
-                diff = make_mu()
-                losses[sig] = diff.abs().mean().sub(noise_f).pow(2)
-            sig = min(losses, key=losses.get)
-            self._noise['all'] = to_inf_inf(sig)
-            self._losses = losses
-        else:
-            raise NotImplementedError('implement grid search!')
+        # *** deprecated: extremely slow! ***
+        # find approx global min on a grid;
+        # if same_sigma:
+        #    grid = torch.arange(.1, 5., 0.2).neg().exp()
+        #    losses = {}
+        #    for sig in grid:
+        #        self._noise['all'] = to_inf_inf(sig)
+        #        diff = make_mu()
+        #        losses[sig] = diff.abs().mean().sub(noise_f).pow(2)
+        #    sig = min(losses, key=losses.get)
+        #    self._noise['all'] = to_inf_inf(sig)
+        #    self._losses = losses
+        # else:
+        #    raise NotImplementedError('implement grid search!')
+
         # find local min
         keys = sorted(self._noise.keys())
         x0 = [float(self._noise[key]) for key in keys]

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -7,6 +7,7 @@ from theforce.regression.algebra import jitcholesky, projected_process_auxiliary
 from theforce.regression.scores import coeff_of_determination
 from theforce.similarity.similarity import SimilarityKernel
 from theforce.util.util import iterable, mkdir_p, safe_dirname
+from theforce.util.parallel import use_max_threads
 from theforce.descriptor.atoms import Local, TorchAtoms, AtomsData, LocalsData
 from collections import Counter
 from scipy.optimize import minimize
@@ -1108,6 +1109,7 @@ def kldiv_normal(y, sigma):
     return loss
 
 
+@use_max_threads
 def _regression(self, optimize=False, noise_f=None, max_noise=0.99, same_sigma=True, wjac=True):
 
     if self.ignore_forces:

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -1242,7 +1242,7 @@ def _regression(self, optimize=False, noise_f=None, max_noise=0.99, same_sigma=T
     make_mu(with_energies=residual)
 
 
-def PosteriorPotentialFromFolder(folder, load_data=True, update_data=True, group=None):
+def PosteriorPotentialFromFolder(folder, load_data=True, update_data=True, group=None, distrib=None):
     from theforce.descriptor.atoms import AtomsData
     from theforce.util.caching import strip_uid
     self = torch.load(os.path.join(folder, 'model'))
@@ -1256,11 +1256,11 @@ def PosteriorPotentialFromFolder(folder, load_data=True, update_data=True, group
         else:
             if hasattr(self, '_raw_data'):
                 self.data = AtomsData(
-                    self._raw_data, convert=True, group=group)
+                    self._raw_data, convert=True, group=group, ranks=distrib)
                 del self._raw_data
             else:  # for backward compatibility
                 self.data = AtomsData(traj=os.path.join(folder, 'data.traj'),
-                                      group=group)
+                                      group=group, ranks=distrib)
             if update_data:
                 self.data.update(
                     cutoff=self.cutoff, descriptors=self.gp.kern.kernels)

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -7,7 +7,6 @@ from theforce.regression.algebra import jitcholesky, projected_process_auxiliary
 from theforce.regression.scores import coeff_of_determination
 from theforce.similarity.similarity import SimilarityKernel
 from theforce.util.util import iterable, mkdir_p, safe_dirname
-from theforce.util.parallel import use_max_threads
 from theforce.descriptor.atoms import Local, TorchAtoms, AtomsData, LocalsData
 from collections import Counter
 from scipy.optimize import minimize
@@ -1112,7 +1111,6 @@ def kldiv_normal(y, sigma):
     return loss
 
 
-@use_max_threads
 def _regression(self, optimize=False, noise_f=None, max_noise=0.99, same_sigma=True, wjac=True):
 
     if self.ignore_forces:

--- a/theforce/regression/gppotential.py
+++ b/theforce/regression/gppotential.py
@@ -671,7 +671,7 @@ class PosteriorPotential(Module):
             self.make_munu()
 
     @context_setting
-    def add_inducing(self, X, remake=True):
+    def add_inducing(self, X, col=None, remake=True):
         assert X.number in self.gp.species
         Ke = self.gp.kern(self.data, X, cov='energy_energy')
         Kf = self.gp.kern(self.data, X, cov='forces_energy')
@@ -684,7 +684,10 @@ class PosteriorPotential(Module):
         else:
             self.Ke = Ke
             self.Kf = Kf
-        a = self.gp.kern(self.X, X, cov='energy_energy')
+        if col is None:
+            a = self.gp.kern(self.X, X, cov='energy_energy')
+        else:
+            a = col
         b = self.gp.kern(X, X, cov='energy_energy')
         self.M = torch.cat(
             [torch.cat([self.M, a.t()]), torch.cat([a, b])], dim=1)

--- a/theforce/util/parallel.py
+++ b/theforce/util/parallel.py
@@ -41,6 +41,10 @@ def index_gather(x, index, size=None):
 
 
 def use_max_threads(func):
+    """
+    This is only experimental.
+    May cause severe performance issues!
+    """
 
     @functools.wraps(func)
     def _func(*args, **kwargs):

--- a/theforce/util/parallel.py
+++ b/theforce/util/parallel.py
@@ -39,7 +39,8 @@ def if_master(func):
         else:
             out = None
         ierr = torch.tensor(ierr)
-        dist.broadcast(ierr, 0)
+        if dist.is_initialized():
+            dist.broadcast(ierr, 0)
         if ierr:
             raise RuntimeError(f'{func.__name__} failed at master')
         return out

--- a/theforce/util/parallel.py
+++ b/theforce/util/parallel.py
@@ -86,8 +86,8 @@ def method_forker(method):
             size = max(shape)
             dim = shape.index(size)
             workers = dist.get_world_size(group=self.process_group)
-            if size < workers:  # TODO: warn or error?
-                warnings.warn('size ({}) < workers ({})'.format(size, workers))
+            # if size < workers:  # TODO: warn or error?
+            #    warnings.warn('size ({}) < workers ({})'.format(size, workers))
             indices = balance_work(size, workers)
             rank = dist.get_rank(group=self.process_group)
             start, end = indices[rank]
@@ -104,7 +104,7 @@ def method_forker(method):
                 dist.broadcast(pieces[k], k, group=self.process_group)
 
             # concat
-            out = torch.cat(pieces, dim=dim)
+            out = torch.cat([p for p in pieces if p.numel() > 0], dim=dim)
             return out
         else:
             return method(self, *args, **kwargs)

--- a/theforce/util/parallel.py
+++ b/theforce/util/parallel.py
@@ -40,6 +40,23 @@ def index_gather(x, index, size=None):
     return _x
 
 
+def use_max_threads(func):
+
+    @functools.wraps(func)
+    def _func(*args, **kwargs):
+        if dist.is_initialized():
+            processes = dist.get_world_size()
+        else:
+            processes = 1
+        nthreads = torch.get_num_threads()
+        torch.set_num_threads(nthreads*processes)
+        out = func(*args, **kwargs)
+        torch.set_num_threads(nthreads)
+        return out
+
+    return _func
+
+
 def balance_work(size, workers):
     # sizes
     a = size//workers


### PR DESCRIPTION
1. reuse some kernel evaluations
2. ioptim > 2 option
3. allow tape=None
3. print wall-time at exit when cl is used
4. distribute atoms evenly across parallel processes
5. faster hyper-parameter optimization (eliminated grid-search for noise scale, just BFGS now).