### PR TITLE
mpi4py dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ In principle, all the calculators supported by the atomic simulation environment
 ([ASE](https://wiki.fysik.dtu.dk/ase/)) can be modeled.
 
 ### Dependencies
-* <ins>Main</ins>: numpy, scipy, pytorch, atomic simulation environment (ASE)
-* <ins>Recommended</ins>: message passing interface (MPI enabled pytorch) for distributed computation.
+* <ins>Main</ins>: numpy, scipy, pytorch, atomic simulation environment (ASE), MPI, mpi4py
 * <ins>Optional</ins>: pymatgen, spglib, mendeleev, matplotlib, nglview, psutil
 
-For enabling distributed computation with MPI,
-pytorch needs to be installed from source
-(see [this](https://github.com/pytorch/pytorch)).
 This package is regularly synced with the latest
 versions of ASE and pytorch.
 Additional setting maybe needed for linking

--- a/theforce/_mpi4py.py
+++ b/theforce/_mpi4py.py
@@ -1,11 +1,22 @@
 # +
 from mpi4py import MPI
 import numpy as np
+import sys
 
 
 comm = MPI.COMM_WORLD
 size = comm.Get_size()
 rank = comm.Get_rank()
+# if mpi4py is available in sys.modules,
+# ase parallelization is activated which
+# apparently has conflicts with theforce
+# since no ase parallelization is assumed.
+# The right way to corrcet the code is
+# to search for all ase function invocations
+# and consider parallelism case by case.
+# For now, the ugly solution is:
+# sys.modules['_mpi4py'] = sys.modules['mpi4py']
+del sys.modules['mpi4py']
 
 
 def is_initialized():

--- a/theforce/_mpi4py.py
+++ b/theforce/_mpi4py.py
@@ -1,0 +1,49 @@
+# +
+from mpi4py import MPI
+import numpy as np
+
+
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+
+def is_initialized():
+    return True
+
+
+class group:
+    WORLD = comm
+
+
+class ReduceOp:
+    MAX = MPI.MAX
+    SUM = MPI.SUM
+
+
+def init_process_group(arg='mpi'):
+    assert arg == 'mpi'
+
+
+def get_world_size(group=comm):
+    return size
+
+
+def get_rank(group=comm):
+    return rank
+
+
+def broadcast(data, src):
+    a = data.detach().numpy()
+    comm.Bcast(a, src)
+
+
+def all_reduce(data, op=ReduceOp.SUM):
+    a = data.detach().numpy().reshape(-1)
+    b = np.zeros_like(a)
+    comm.Allreduce(a, b, op)
+    a[:] = b[:]
+
+
+def barrier():
+    comm.Barrier()

--- a/theforce/cl/__init__.py
+++ b/theforce/cl/__init__.py
@@ -5,7 +5,7 @@ from theforce.calculator.socketcalc import SocketCalculator
 from theforce.calculator.active import ActiveCalculator, kcal_mol, inf, SeSoapKernel, DefaultRadii, ActiveMeta
 from theforce.calculator.meta import Meta, Posvar, Qlvar, Catvar
 import torch
-import torch.distributed as dist
+import theforce.distributed as dist
 import os
 import time
 import atexit

--- a/theforce/deprecated/calculator/posterior.py
+++ b/theforce/deprecated/calculator/posterior.py
@@ -57,7 +57,7 @@ class PosteriorStressCalculator(Calculator):
         stress1 = -(forces[:, None]*self.atoms.xyz[..., None]).sum(dim=0)
         cellgrad, = grad(energy, self.atoms.lll)
         if self.atoms.is_distributed:
-            torch.distributed.all_reduce(cellgrad)
+            distrib.all_reduce(cellgrad)
         stress2 = (cellgrad[:, None]*self.atoms.lll[..., None]).sum(dim=0)
         stress = (stress1 + stress2).detach().numpy() / self.atoms.get_volume()
         # results
@@ -128,14 +128,14 @@ class AutoForceCalculator(Calculator):
                      allow_unused=True)[0]
         forces = torch.zeros_like(self.atoms.xyz) if rgrad is None else -rgrad
         if self.atoms.is_distributed:
-            torch.distributed.all_reduce(forces)
+            distrib.all_reduce(forces)
         # stress
         stress1 = -(forces[:, None]*self.atoms.xyz[..., None]).sum(dim=0)
         cellgrad, = grad(energy, self.atoms.lll, allow_unused=True)
         if cellgrad is None:
             cellgrad = torch.zeros_like(self.atoms.lll)
         if self.atoms.is_distributed:
-            torch.distributed.all_reduce(cellgrad)
+            distrib.all_reduce(cellgrad)
         stress2 = (cellgrad[:, None]*self.atoms.lll[..., None]).sum(dim=0)
         try:
             volume = self.atoms.get_volume()

--- a/theforce/deprecated/cl/vasp.py
+++ b/theforce/deprecated/cl/vasp.py
@@ -1,5 +1,5 @@
 # +
-import torch.distributed as dist
+import theforce.distributed as dist
 from theforce.util.parallel import mpi_init
 from theforce.cl.mlmd import mlmd, read_md
 from theforce.cl import ARGS

--- a/theforce/deprecated/dynamics/leapfrog.py
+++ b/theforce/deprecated/dynamics/leapfrog.py
@@ -129,8 +129,8 @@ class Leapfrog:
 
     @property
     def rank(self):
-        if torch.distributed.is_initialized():
-            return torch.distributed.get_rank()
+        if distrib.is_initialized():
+            return distrib.get_rank()
         else:
             return 0
 

--- a/theforce/deprecated/run/aneal.py
+++ b/theforce/deprecated/run/aneal.py
@@ -6,7 +6,7 @@ from theforce.util.aseutil import get_repeat_reciprocal
 from theforce.deprecated.util.pmgen import standard_cell
 from theforce.util.util import date
 from ase.units import Pascal, GPa
-import torch.distributed as dist
+import theforce.distributed as dist
 from ase.io import read
 import numpy as np
 from string import ascii_lowercase as letters

--- a/theforce/deprecated/run/fly.py
+++ b/theforce/deprecated/run/fly.py
@@ -68,7 +68,7 @@ def clear_all():
 
 def numpy_same_random_seed():
     seed = torch.tensor(np.random.randint(2**32))
-    torch.distributed.broadcast(seed, 0)
+    distrib.broadcast(seed, 0)
     np.random.seed(seed.numpy())
 
 
@@ -156,5 +156,5 @@ def fly(temperature, updates, atoms=None, cutoff=None, au=None, calc=None, kern=
     if calc is None:
         clean_vasp()
     if group is not None:
-        torch.distributed.barrier()
+        distrib.barrier()
     return dyn.model

--- a/theforce/deprecated/run/run_dyn.py
+++ b/theforce/deprecated/run/run_dyn.py
@@ -1,6 +1,6 @@
 from theforce.regression.gppotential import PosteriorPotentialFromFolder
 from theforce.calculator.posterior import AutoForceCalculator
-import torch.distributed as dist
+import theforce.distributed as dist
 
 
 def extremum(e):

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -543,7 +543,7 @@ class TorchAtoms(Atoms):
     def gathered(self, folder='atoms'):
         if self.is_distributed and len(self.loc) < self.natoms:
             self.pickle_locals(folder=folder)
-            dist.barrier(self.process_group)
+            dist.barrier()  # barrier(self.process_group) changed for _mpi4py
             loc = self.pickles()
         else:
             loc = self.loc

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -2,7 +2,7 @@
 import numpy as np
 import torch
 from torch import ones_like, as_tensor, from_numpy, cat
-import torch.distributed as dist
+import theforce.distributed as dist
 from ase.atoms import Atoms
 from ase.neighborlist import NeighborList
 from ase.calculators.singlepoint import SinglePointCalculator
@@ -10,6 +10,7 @@ import copy
 import warnings
 from theforce.util.util import iterable, mkdir_p
 from theforce.util.parallel import balance_work
+import theforce.distributed as distrib
 from collections import Counter
 import random
 import itertools
@@ -303,14 +304,14 @@ class TorchAtoms(Atoms):
 
     def index_distribute(self, randomize=True):
         if self.is_distributed:
-            rank = torch.distributed.get_rank(group=self.process_group)
+            rank = distrib.get_rank(group=self.process_group)
             if self.ranks:
                 self.indices = []
                 for i, j in enumerate(self.ranks):
                     if j == rank:
                         self.indices.append(i)
             else:
-                workers = torch.distributed.get_world_size(
+                workers = distrib.get_world_size(
                     group=self.process_group)
                 indices = balance_work(self.natoms, workers)
                 if randomize:

--- a/theforce/distributed.py
+++ b/theforce/distributed.py
@@ -1,5 +1,8 @@
 # +
-import torch.distributed as _dist
+if True:
+    import torch.distributed as _dist
+else:
+    import theforce._mpi4py as _dist
 
 
 group = _dist.group
@@ -10,3 +13,4 @@ get_world_size = _dist.get_world_size
 get_rank = _dist.get_rank
 barrier = _dist.barrier
 all_reduce = _dist.all_reduce
+ReduceOp = _dist.ReduceOp

--- a/theforce/distributed.py
+++ b/theforce/distributed.py
@@ -1,5 +1,5 @@
 # +
-if True:
+if False:
     import torch.distributed as _dist
 else:
     import theforce._mpi4py as _dist

--- a/theforce/distributed.py
+++ b/theforce/distributed.py
@@ -1,0 +1,12 @@
+# +
+import torch.distributed as _dist
+
+
+group = _dist.group
+is_initialized = _dist.is_initialized
+init_process_group = _dist.init_process_group
+broadcast = _dist.broadcast
+get_world_size = _dist.get_world_size
+get_rank = _dist.get_rank
+barrier = _dist.barrier
+all_reduce = _dist.all_reduce

--- a/theforce/util/parallel.py
+++ b/theforce/util/parallel.py
@@ -1,6 +1,6 @@
 # +
 from theforce.util.util import iterable
-import torch.distributed as dist
+import theforce.distributed as dist
 import torch
 import numpy as np
 import functools


### PR DESCRIPTION
From now on, we use mpi4py for MPI parallelism back-end.
Previously we used torch.distributed which required compilation of pytorch from the source.
With this update, installation of pytorch can be handled by conda.