### PR TITLE
Incorporate a kernel function to enhance stress estimation.

### DIFF
--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -308,7 +308,7 @@ class TorchAtoms(Atoms):
                 if "forces" in ase_atoms.calc.results:
                     self.target_forces = as_tensor(ase_atoms.get_forces())
                 if "stress" in ase_atoms.calc.results:
-                    self.target_forces = as_tensor(ase_atoms.get_stress())
+                    self.target_stress = as_tensor(ase_atoms.get_stress())
 
     def set_targets(self):
         self.target_energy = as_tensor(self.get_potential_energy())

--- a/theforce/descriptor/atoms.py
+++ b/theforce/descriptor/atoms.py
@@ -267,6 +267,7 @@ class TorchAtoms(Atoms):
         ase_atoms=None,
         energy=None,
         forces=None,
+        stress=None,
         cutoff=None,
         descriptors=[],
         group=None,
@@ -299,16 +300,20 @@ class TorchAtoms(Atoms):
         if energy is not None and forces is not None:
             self.target_energy = as_tensor(energy)
             self.target_forces = as_tensor(forces)
+            self.target_stress = as_tensor(stress)
         else:
             if ase_atoms is not None and ase_atoms.get_calculator() is not None:
                 if "energy" in ase_atoms.calc.results:
                     self.target_energy = as_tensor(ase_atoms.get_potential_energy())
                 if "forces" in ase_atoms.calc.results:
                     self.target_forces = as_tensor(ase_atoms.get_forces())
+                if "stress" in ase_atoms.calc.results:
+                    self.target_forces = as_tensor(ase_atoms.get_stress())
 
     def set_targets(self):
         self.target_energy = as_tensor(self.get_potential_energy())
         self.target_forces = as_tensor(self.get_forces())
+        self.target_stress = as_tensor(self.get_stress())
 
     def attach_process_group(self, group):
         self.process_group = group

--- a/theforce/distributed.py
+++ b/theforce/distributed.py
@@ -1,8 +1,9 @@
 # +
 import torch
 
-if torch.distributed.is_mpi_available():
-    import torch.distributed as _dist
+if torch.distributed.is_available():
+    if torch.distributed.is_mpi_available():
+        import torch.distributed as _dist
 else:
     import theforce._mpi4py as _dist
 

--- a/theforce/regression/algebra.py
+++ b/theforce/regression/algebra.py
@@ -29,7 +29,7 @@ def sum_packed_dim(packed, sizes, dim=-1):
 def jitcholesky(A, jit=1e-6, jitbase=2):
     ridge = 0
     try:
-        L = torch.cholesky(A)
+        L = torch.linalg.cholesky(A)
     except RuntimeError:
         scale = A.diag().mean()
         if scale == torch.zeros(1):
@@ -38,7 +38,7 @@ def jitcholesky(A, jit=1e-6, jitbase=2):
         done = False
         while not done:
             try:
-                L = torch.cholesky(A + ridge * torch.eye(*A.size(), dtype=A.dtype))
+                L = torch.linalg.cholesky(A + ridge * torch.eye(*A.size(), dtype=A.dtype))
                 done = True
             except RuntimeError:
                 ridge *= jitbase
@@ -110,7 +110,7 @@ def projected_process_auxiliary_matrices_I(K, M, Y, sigma):
     i = L.inverse()
     B = K @ i.t()
     I = torch.eye(i.size(0))
-    T = torch.cholesky(B.t() @ B / sigma**2 + I)
+    T = torch.linalg.cholesky(B.t() @ B / sigma**2 + I)
     nu = i.t() @ (I - torch.cholesky_inverse(T)) @ i
     return mu, nu
 

--- a/theforce/similarity/similarity.py
+++ b/theforce/similarity/similarity.py
@@ -51,6 +51,10 @@ class SimilarityKernel(Module):
         return self.get_rightgrad(p, q)
 
     @method_caching
+    def virial(self, p, q):
+        return self.get_virial(p, q)
+    
+    @method_caching
     def gradgrad(self, p, q):
         return self.get_gradgrad(p, q)
 


### PR DESCRIPTION
I incorporate a kernel function to enhance stress estimation. For example, when we solve [Ke, Kf, Kv, L] \mu = [Y, 0], where Kv represents the kernel values for stress (or virial) Y = [energy, forces, stress (or virial)], the solved \mu can give the better stress.