### PR TITLE
torch.set_default_tensor_type was deprecated as of PyTorch 2.1

### DIFF
--- a/theforce/__init__.py
+++ b/theforce/__init__.py
@@ -9,7 +9,7 @@ if not hasattr(np, "float"):
 # +
 import torch
 
-torch.set_default_tensor_type(torch.DoubleTensor)
+#torch.set_default_tensor_type(torch.DoubleTensor)
 torch.set_default_dtype(torch.double)
 if int(torch.__version__.split(".")[1]) > 7:
     torch.cholesky = torch.linalg.cholesky


### PR DESCRIPTION
torch.set_default_tensor_type was deprecated as of PyTorch 2.1